### PR TITLE
formatting: %+v should apply to nested errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -109,7 +109,7 @@ func (merr multiError) writeMultiline(w io.Writer) {
 	w.Write(_multilinePrefix)
 	for _, item := range merr {
 		w.Write(_multilineSeparator)
-		writePrefixLine(w, _multilineIndent, item.Error())
+		writePrefixLine(w, _multilineIndent, fmt.Sprintf("%+v", item))
 	}
 }
 


### PR DESCRIPTION
`%+v` on a multierr should use `%+v` on the nested errors. That is,

    fmt.Sprintf("%+v", multierr.Combine(err1, err2))

Should use `fmt.Sprintf("%+v", err1)` and `fmt.Sprinf("%+v", err2)` in
the output rather than `err{1, 2}.Error()`.

CC @prashantv