### PR TITLE
Fix Append modifying a possibly shared array

### DIFF
--- a/error.go
+++ b/error.go
@@ -264,14 +264,10 @@ func Append(left error, right error) error {
 	}
 
 	if _, ok := right.(multiError); !ok {
-		if l, ok := left.(multiError); ok {
-			// Common case where the error on the left is constantly being
-			// appended to.
-			return append(l, right)
+		if _, ok := left.(multiError); !ok {
+			// Both errors are single errors.
+			return multiError{left, right}
 		}
-
-		// Both errors are single errors.
-		return multiError{left, right}
 	}
 
 	// Either right or both, left and right, are multiErrors. Rely on usual


### PR DESCRIPTION
It's possible to have a multiError that is appended to multiple times
causing an underlying array to be shared and end up getting modified.

For now, remove the special case for `append(multiError, err)` which can
cause this bug.