### PR TITLE
Avoid allocating a new slice on every Append

### DIFF
--- a/error.go
+++ b/error.go
@@ -106,7 +106,7 @@ func (merr *multiError) writeSingleline(w io.Writer) {
 	}
 }
 
-func (merr multiError) writeMultiline(w io.Writer) {
+func (merr *multiError) writeMultiline(w io.Writer) {
 	w.Write(_multilinePrefix)
 	for _, item := range merr.errors {
 		w.Write(_multilineSeparator)

--- a/error.go
+++ b/error.go
@@ -75,10 +75,6 @@ type multiError struct {
 	errors     []error
 }
 
-// func (merr *multiError) String() string {
-// 	return merr.Error()
-// }
-
 func (merr *multiError) Error() string {
 	buff := _bufferPool.Get().(*bytes.Buffer)
 	buff.Reset()

--- a/error_test.go
+++ b/error_test.go
@@ -333,7 +333,7 @@ func TestAppend(t *testing.T) {
 func createMultiErrWithCapacity() error {
 	// Create a multiError that has capacity for more errors so Append will
 	// modify the underlying array that may be shared.
-	return appendN(nil, errors.New("initial"), 50)
+	return appendN(nil, errors.New("append"), 50)
 }
 
 func TestAppendDoesNotModify(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -343,10 +343,10 @@ func TestAppendDoesNotModify(t *testing.T) {
 
 	// Make sure the error messages match, since we do modify the copyNeeded
 	// atomic, the values cannot be compared.
-	assert.Equal(t, createMultiErrWithCapacity().Error(), initial.Error(), "Initial should not be modified")
+	assert.EqualError(t, initial, createMultiErrWithCapacity().Error(), "Initial should not be modified")
 
-	assert.Equal(t, Append(createMultiErrWithCapacity(), errors.New("err1")), err1)
-	assert.Equal(t, Append(createMultiErrWithCapacity(), errors.New("err2")), err2)
+	assert.EqualError(t, err1, Append(createMultiErrWithCapacity(), errors.New("err1")).Error())
+	assert.EqualError(t, err2, Append(createMultiErrWithCapacity(), errors.New("err2")).Error())
 }
 
 func TestAppendRace(t *testing.T) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,16 +1,19 @@
-hash: cb430176250bcfe8bafd93aa48d285fa35b08af59b5f9971dcf553a1d6c236ec
-updated: 2017-03-17T16:22:25.024129734-07:00
-imports: []
+hash: b53b5e9a84b9cb3cc4b2d0499e23da2feca1eec318ce9bb717ecf35bf24bf221
+updated: 2017-04-10T13:34:45.671678062-07:00
+imports:
+- name: go.uber.org/atomic
+  version: 3b8db5e93c4c02efbc313e17b2e796b0914a01fb
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 346938d642f2ec3594ed81d874461961cd0faa76
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
+  - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: go.uber.org/multierr
-import: []
+import:
+- package: go.uber.org/atomic
+  version: ^1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:


### PR DESCRIPTION
Currently, appending a non-nil error to a multierror always copies the underlying slice, since there may be multiple goroutines appending to the same multierr,
```go
merr := multierr.Append(errors.New("initial"), errors.New("multierr"))
go func() {
  err1 = multierr.Append(merr, errors.New("1"))
  [..]
}()
go func() {
  err2 = multierr.Append(merr, errors.New("2"))
  [..]
}()
```

However, the common use case is a standard for loop:
```go
var merr error
for _, v := range values {
  merr = multierr.Append(merr, processValue(v))
}
return merr
```

Since there is only a single resulting slice, we don't need to create a full copy on every `Append`. Instead, we track whether we have modified the underlying slice from `Append` already using an atomic boolean, and only create a copy if the underlying slice has been modified.