### PR TITLE
Graceful handling of nil errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -76,6 +76,10 @@ type multiError struct {
 }
 
 func (merr *multiError) Error() string {
+	if merr == nil {
+		return ""
+	}
+
 	buff := _bufferPool.Get().(*bytes.Buffer)
 	buff.Reset()
 

--- a/error_test.go
+++ b/error_test.go
@@ -367,3 +367,11 @@ func TestAppendRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestNilMultierror(t *testing.T) {
+	// For safety, all operations on multiError should be safe even if it is
+	// nil.
+	var err *multiError
+
+	require.Empty(t, err.Error())
+}


### PR DESCRIPTION
We shouldn't panic if *multiError is nil.