### PR TITLE
Add AppendInto function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Releases
 ========
 
+v1.4.0 (unreleased)
+===================
+
+-   Add `AppendInto` function to more ergonomically build errors inside a
+    loop.
+
+
 v1.3.0 (2019-10-29)
 ===================
 

--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -396,4 +396,47 @@ func Append(left error, right error) error {
 	// expensive logic.
 	errors := [2]error{left, right}
 	return fromSlice(errors[0:])
+}
+
+// AppendInto appends an error into the destination of an error pointer and
+// returns whether the error being appended was non-nil.
+//
+// 	var err error
+// 	multierr.AppendInto(&err, r.Close())
+// 	multierr.AppendInto(&err, w.Close())
+//
+// The above is equivalent to,
+//
+// 	err := multierr.Append(r.Close(), w.Close())
+//
+// As AppendInto reports whether the provided error was non-nil, it may be
+// used to build a multierr error in a loop more ergonomically.
+//
+// 	var err error
+// 	for line := range lines {
+// 		var item Item
+// 		if multierr.AppendInto(&err, parse(line, &item)) {
+// 			continue
+// 		}
+// 		items = append(items, item)
+// 	}
+//
+// Compare the loop body above with a version that relies solely on Append.
+//
+// 	var item Item
+// 	if parseErr := parse(line, &item); parseErr != nil {
+// 		err = multierr.Append(err, parseErr)
+// 		continue
+// 	}
+// 	items = append(items, item)
+func AppendInto(into *error, err error) (errored bool) {
+	if err == nil {
+		return false
+	}
+	// We will panic if 'into' is nil. This is not documented above
+	// because suggesting that the pointer must be non-nil may confuse
+	// users into thinking that the error that it points to must be
+	// non-nil.
+	*into = Append(*into, err)
+	return true
 }

--- a/error.go
+++ b/error.go
@@ -423,12 +423,15 @@ func Append(left error, right error) error {
 //
 // Compare this with a verison that relies solely on Append:
 //
-// 	var item Item
-// 	if parseErr := parse(line, &item); parseErr != nil {
-// 		err = multierr.Append(err, parseErr)
-// 		continue
+// 	var err error
+// 	for line := range lines {
+// 		var item Item
+// 		if parseErr := parse(line, &item); parseErr != nil {
+// 			err = multierr.Append(err, parseErr)
+// 			continue
+// 		}
+// 		items = append(items, item)
 // 	}
-// 	items = append(items, item)
 func AppendInto(into *error, err error) (errored bool) {
 	if into == nil {
 		// We panic if 'into' is nil. This is not documented above

--- a/error.go
+++ b/error.go
@@ -410,7 +410,7 @@ func Append(left error, right error) error {
 // 	err := multierr.Append(r.Close(), w.Close())
 //
 // As AppendInto reports whether the provided error was non-nil, it may be
-// used to build a multierr error in a loop more ergonomically.
+// used to build a multierr error in a loop more ergonomically. For example:
 //
 // 	var err error
 // 	for line := range lines {
@@ -421,7 +421,7 @@ func Append(left error, right error) error {
 // 		items = append(items, item)
 // 	}
 //
-// Compare the loop body above with a version that relies solely on Append.
+// Compare this with a verison that relies solely on Append:
 //
 // 	var item Item
 // 	if parseErr := parse(line, &item); parseErr != nil {

--- a/error.go
+++ b/error.go
@@ -430,13 +430,17 @@ func Append(left error, right error) error {
 // 	}
 // 	items = append(items, item)
 func AppendInto(into *error, err error) (errored bool) {
+	if into == nil {
+		// We panic if 'into' is nil. This is not documented above
+		// because suggesting that the pointer must be non-nil may
+		// confuse users into thinking that the error that it points
+		// to must be non-nil.
+		panic("misuse of multierr.AppendInto: into pointer must not be nil")
+	}
+
 	if err == nil {
 		return false
 	}
-	// We will panic if 'into' is nil. This is not documented above
-	// because suggesting that the pointer must be non-nil may confuse
-	// users into thinking that the error that it points to must be
-	// non-nil.
 	*into = Append(*into, err)
 	return true
 }

--- a/example_test.go
+++ b/example_test.go
@@ -70,3 +70,25 @@ func ExampleErrors() {
 	// call 3 failed
 	// call 5 failed
 }
+
+func ExampleAppendInto() {
+	var err error
+
+	if multierr.AppendInto(&err, errors.New("foo")) {
+		fmt.Println("call 1 failed")
+	}
+
+	if multierr.AppendInto(&err, nil) {
+		fmt.Println("call 2 failed")
+	}
+
+	if multierr.AppendInto(&err, errors.New("baz")) {
+		fmt.Println("call 3 failed")
+	}
+
+	fmt.Println(err)
+	// Output:
+	// call 1 failed
+	// call 3 failed
+	// foo; baz
+}


### PR DESCRIPTION
This adds an AppendInto function that behaves similarly to Append
except, it operates on a `*error` on the left side and it reports
whether the right side error was non-nil.

    func AppendInto(*error, error) (errored bool)

Making the left side a pointer aligns with the fast path of `Append`.

Returning whether the right error was non-nil aligns with the standard
`if err := ...; err != nil` pattern.

```diff
-if err := thing(); err != nil {
+if multierr.AppendInto(&err, thing()) {
   continue
 }
```

Resolves #21