### PR TITLE
Missing error value in example usage

### DIFF
--- a/error.go
+++ b/error.go
@@ -54,7 +54,7 @@
 //
 // 	errors := multierr.Errors(err)
 // 	if len(errors) > 0 {
-// 		fmt.Println("The following errors occurred:")
+// 		fmt.Println("The following errors occurred:", errors)
 // 	}
 //
 // Advanced Usage


### PR DESCRIPTION
Reading the docs gives me a pulse here, I believe this is the right way to fix it.