### PR TITLE
Prepare release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Releases
 ========
 
-v1.6.0 (unreleased)
+v1.6.0 (2020-09-14)
 ===================
 
 -   Actually drop library dependency on development-time tooling.


### PR DESCRIPTION
Release v1.6.0 that drops the library dependency on dev-time tooling
completely.
