### PR TITLE
use strings.Builder instead of bytes buffer

### DIFF
--- a/error.go
+++ b/error.go
@@ -86,12 +86,10 @@
 package multierr // import "go.uber.org/multierr"
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
-	"sync"
 
 	"go.uber.org/atomic"
 )
@@ -118,13 +116,6 @@ var (
 	_multilineSeparator = []byte("\n -  ")
 	_multilineIndent    = []byte("    ")
 )
-
-// _bufferPool is a pool of bytes.Buffers.
-var _bufferPool = sync.Pool{
-	New: func() interface{} {
-		return &bytes.Buffer{}
-	},
-}
 
 type errorGroup interface {
 	Errors() []error
@@ -218,15 +209,9 @@ func (merr *multiError) Error() string {
 	if merr == nil {
 		return ""
 	}
-
-	buff := _bufferPool.Get().(*bytes.Buffer)
-	buff.Reset()
-
+	buff := &strings.Builder{}
 	merr.writeSingleline(buff)
-
-	result := buff.String()
-	_bufferPool.Put(buff)
-	return result
+	return buff.String()
 }
 
 func (merr *multiError) Format(f fmt.State, c rune) {

--- a/error_legacy.go
+++ b/error_legacy.go
@@ -1,0 +1,30 @@
+// +build legacy
+
+package multierr
+
+import (
+	"bytes"
+	"sync"
+)
+
+// _bufferPool is a pool of bytes.Buffers.
+var _bufferPool = sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+func (merr *multiError) oldError() string {
+	if merr == nil {
+		return ""
+	}
+
+	buff := _bufferPool.Get().(*bytes.Buffer)
+	buff.Reset()
+
+	merr.writeSingleline(buff)
+
+	result := buff.String()
+	_bufferPool.Put(buff)
+	return result
+}

--- a/errors_bench_test.go
+++ b/errors_bench_test.go
@@ -1,0 +1,57 @@
+// +build legacy
+
+package multierr
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+var testErrors []*multiError
+var sampleText = strings.Repeat("sampletext", 10)
+
+type testErr string
+
+func (e testErr) Error() string { return string(e) }
+
+const (
+	nErrors = 2 << 10
+	seed    = 8012
+)
+
+func init() {
+	var rnd = rand.New(rand.NewSource(seed))
+	var maxText = len(sampleText)
+	var row []error
+	for i := 0; i < nErrors; i++ {
+		row = row[:0]
+		var toGenerate = rnd.Intn(3) + 2
+		for j := 0; j < toGenerate; j++ {
+			var n = rnd.Intn(maxText) + 1
+			var text = sampleText[:n]
+			row = append(row, testErr(text))
+		}
+		testErrors = append(testErrors, Combine(row...).(*multiError))
+	}
+}
+
+var dump string
+
+func BenchmarkError(bench *testing.B) {
+	bench.ReportAllocs()
+	for i := 0; i < bench.N; i++ {
+		for _, err := range testErrors {
+			dump = err.Error()
+		}
+	}
+}
+
+func BenchmarkErrorLegacy(bench *testing.B) {
+	bench.ReportAllocs()
+	for i := 0; i < bench.N; i++ {
+		for _, err := range testErrors {
+			dump = err.oldError()
+		}
+	}
+}


### PR DESCRIPTION
Using `strings.Builder` will remove unnessary allocations, since there will be no `interface{}` type casts. Unlike `bytes.Buffer`, `strings.Builder` does not copy memory when converting to a string.