### PR TITLE
Release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Releases
 ========
 
-v1.7.0 (unreleased)
+v1.7.0 (2021-05-06)
 ===================
 
 -   Add `AppendInvoke` to append into errors from `defer` blocks.


### PR DESCRIPTION
Release v1.7.0 of multierr with `AppendInvoke` support.

Depends on #49
