### PR TITLE
Add multierr.Is(err, target)

### DIFF
--- a/error.go
+++ b/error.go
@@ -215,6 +215,24 @@ func Errors(err error) []error {
 	return result
 }
 
+// Is attempts to match the provided error against errors of a multierror.
+//
+// This function behaves similarly to errors.Is, but, if a multierror is
+// passed, will use through those.
+func Is(err, target error) bool {
+	// If err is exactly equal to target, short-circuit the check.
+	// It also captures when both err and target are multierrors.
+	if err == target {
+		return true
+	}
+	eg, ok := err.(*multiError)
+	if !ok {
+		return errors.Is(err, target)
+	}
+
+	return eg.Is(target)
+}
+
 // multiError is an error that holds one or more errors.
 //
 // An instance of this is guaranteed to be non-empty and flattened. That is,

--- a/error_ext_test.go
+++ b/error_ext_test.go
@@ -57,6 +57,7 @@ func TestErrorsWrapping(t *testing.T) {
 		errGreatSadness{42},
 		errUnprecedentedFailure{43},
 	)
+	err1 := err.(error)
 
 	t.Run("left", func(t *testing.T) {
 		t.Run("As", func(t *testing.T) {
@@ -67,7 +68,9 @@ func TestErrorsWrapping(t *testing.T) {
 
 		t.Run("Is", func(t *testing.T) {
 			assert.False(t, errors.Is(err, errGreatSadness{41}))
+			assert.False(t, multierr.Is(err1, errGreatSadness{41}))
 			assert.True(t, errors.Is(err, errGreatSadness{42}))
+			assert.True(t, multierr.Is(err1, errGreatSadness{42}))
 		})
 	})
 
@@ -80,7 +83,9 @@ func TestErrorsWrapping(t *testing.T) {
 
 		t.Run("Is", func(t *testing.T) {
 			assert.False(t, errors.Is(err, errUnprecedentedFailure{42}))
+			assert.False(t, multierr.Is(err1, errUnprecedentedFailure{42}))
 			assert.True(t, errors.Is(err, errUnprecedentedFailure{43}))
+			assert.True(t, multierr.Is(err1, errUnprecedentedFailure{43}))
 		})
 	})
 
@@ -93,6 +98,7 @@ func TestErrorsWrapping(t *testing.T) {
 
 		t.Run("Is", func(t *testing.T) {
 			assert.True(t, errors.Is(err, err))
+			assert.True(t, multierr.Is(err1, err1))
 		})
 	})
 
@@ -105,7 +111,9 @@ func TestErrorsWrapping(t *testing.T) {
 
 		t.Run("Is", func(t *testing.T) {
 			assert.False(t, errors.Is(err, errRootCause{42}))
+			assert.False(t, multierr.Is(err1, errRootCause{42}))
 			assert.True(t, errors.Is(err, errRootCause{43}))
+			assert.True(t, multierr.Is(err1, errRootCause{43}))
 		})
 	})
 
@@ -117,6 +125,7 @@ func TestErrorsWrapping(t *testing.T) {
 
 		t.Run("Is", func(t *testing.T) {
 			assert.False(t, errors.Is(err, errors.New("great sadness")))
+			assert.False(t, multierr.Is(err1, errors.New("great sadness")))
 		})
 	})
 }
@@ -136,7 +145,10 @@ func TestErrorsWrappingSameType(t *testing.T) {
 
 	t.Run("Is matches all", func(t *testing.T) {
 		assert.True(t, errors.Is(err, errGreatSadness{1}))
+		assert.True(t, multierr.Is(err, errGreatSadness{1}))
 		assert.True(t, errors.Is(err, errGreatSadness{2}))
+		assert.True(t, multierr.Is(err, errGreatSadness{2}))
 		assert.True(t, errors.Is(err, errGreatSadness{3}))
+		assert.True(t, multierr.Is(err, errGreatSadness{3}))
 	})
 }


### PR DESCRIPTION
This is useful when the caller receives `error` type, and would like to
know if the error is of particular interest, in case it is a multierror.

Imagine a program `usergroups` that emits many lines to stdout, and is
used like this:

```
#!/bin/bash
set -o pipefail
echo "First 20 users:"
usergroups users | head -20
echo "First 20 groups:"
usergroups groups | head -20
```

After 20 lines have been printed, stdout will be closed, and subsequent
`os.Stdout.Write(...)` calls will fail. If we are checking for errors
from the `Write` calls, the application should terminate with non-zero
exit code. That way, the script will terminate after 3 lines and will
ignore the poor groups.

However, in this case, `| head` is a user's choice, thus a closed
stdout/stderr is usually expected, and should not fail the program.

What to do? Close the program normally if stdout/stderr cannot be
written to. To detect it, it's often convenient to use
`multierr.Append`. Callee:

```
type ErrBadSink = errors.New("bad sink")
func execute(w io.Writer) error {
    if _, err := io.WriteString(w, "---header---"); err != nil {
        return multierr.Append(err, ErrBadSink)
    }
    if err := <...>; err != nil {
        return fmt.Errorf("other kind of error: %w")
    }
}
```

Caller would like to know whether the error is `ErrBadSink`. In my case,
if it is, it should terminate the program differently:

```
func main() {
    if err := execute(os.Stdout); err != nil {
        if multierr.Is(err, ErrBadSink) {
            // writing to stdout failed. Probably caused by a closed
            // file descriptor, say, because of `| head`. Terminate
            // successfully.
            os.Exit(0)
        }
        fmt.Fprintf(os.Stderr, "failed to run command: %s", err)
    }
}
```

This change allows testing the plain `error` types against
`multierr.Is`.