### PR TITLE
doc: AppendInvoke: Fix typo

### DIFF
--- a/error.go
+++ b/error.go
@@ -103,7 +103,7 @@
 // 		if err != nil {
 // 			return err
 // 		}
-// 		defer multierr.AppendInvoke(err, multierr.Close(conn))
+// 		defer multierr.AppendInvoke(&err, multierr.Close(conn))
 // 		// ...
 // 	}
 //


### PR DESCRIPTION
One of the examples for AppendInvoke used `AppendInvoke(err, ...)` but
the argument is supposed to be a `*error`. Fix the example.