### PR TITLE
Optimize Combine for all nil scenarios

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -60,3 +60,42 @@ func BenchmarkAppend(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCombine(b *testing.B) {
+	b.Run("inline 1", func(b *testing.B) {
+		var x error
+		for i := 0; i < b.N; i++ {
+			Combine(x)
+		}
+	})
+
+	b.Run("inline 2", func(b *testing.B) {
+		var x, y error
+		for i := 0; i < b.N; i++ {
+			Combine(x, y)
+		}
+	})
+
+	b.Run("inline 3", func(b *testing.B) {
+		var x, y, z error
+		for i := 0; i < b.N; i++ {
+			Combine(x, y, z)
+		}
+	})
+
+	b.Run("inline 3 with error", func(b *testing.B) {
+		var x, y, z error
+		z = fmt.Errorf("failed")
+		for i := 0; i < b.N; i++ {
+			Combine(x, y, z)
+		}
+	})
+
+	b.Run("slice", func(b *testing.B) {
+		var x, y, z error
+		for i := 0; i < b.N; i++ {
+			errs := []error{x, y, z}
+			Combine(errs...)
+		}
+	})
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -102,25 +102,25 @@ func BenchmarkCombine(b *testing.B) {
 	})
 
 	b.Run("slice 100 no errors", func(b *testing.B) {
+		errs := make([]error, 100)
 		for i := 0; i < b.N; i++ {
-			errs := make([]error, 100)
 			Combine(errs...)
 		}
 	})
 
 	b.Run("slice 100 one error", func(b *testing.B) {
+		errs := make([]error, 100)
+		errs[len(errs)-1] = fmt.Errorf("failed")
 		for i := 0; i < b.N; i++ {
-			errs := make([]error, 100)
-			errs[len(errs)-1] = fmt.Errorf("failed")
 			Combine(errs...)
 		}
 	})
 
 	b.Run("slice 100 multi error", func(b *testing.B) {
+		errs := make([]error, 100)
+		errs[0] = fmt.Errorf("failed1")
+		errs[len(errs)-1] = fmt.Errorf("failed2")
 		for i := 0; i < b.N; i++ {
-			errs := make([]error, 100)
-			errs[0] = fmt.Errorf("failed1")
-			errs[len(errs)-1] = fmt.Errorf("failed2")
 			Combine(errs...)
 		}
 	})

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -76,14 +76,14 @@ func BenchmarkCombine(b *testing.B) {
 		}
 	})
 
-	b.Run("inline 3", func(b *testing.B) {
+	b.Run("inline 3 no error", func(b *testing.B) {
 		var x, y, z error
 		for i := 0; i < b.N; i++ {
 			Combine(x, y, z)
 		}
 	})
 
-	b.Run("inline 3 with error", func(b *testing.B) {
+	b.Run("inline 3 one error", func(b *testing.B) {
 		var x, y, z error
 		z = fmt.Errorf("failed")
 		for i := 0; i < b.N; i++ {
@@ -91,10 +91,36 @@ func BenchmarkCombine(b *testing.B) {
 		}
 	})
 
-	b.Run("slice", func(b *testing.B) {
+	b.Run("inline 3 multiple errors", func(b *testing.B) {
 		var x, y, z error
+		z = fmt.Errorf("failed3")
+		y = fmt.Errorf("failed2")
+		x = fmt.Errorf("failed")
 		for i := 0; i < b.N; i++ {
-			errs := []error{x, y, z}
+			Combine(x, y, z)
+		}
+	})
+
+	b.Run("slice 100 no errors", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			errs := make([]error, 100)
+			Combine(errs...)
+		}
+	})
+
+	b.Run("slice 100 one error", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			errs := make([]error, 100)
+			errs[len(errs)-1] = fmt.Errorf("failed")
+			Combine(errs...)
+		}
+	})
+
+	b.Run("slice 100 multi error", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			errs := make([]error, 100)
+			errs[0] = fmt.Errorf("failed1")
+			errs[len(errs)-1] = fmt.Errorf("failed2")
 			Combine(errs...)
 		}
 	})

--- a/error.go
+++ b/error.go
@@ -434,7 +434,32 @@ func fromSlice(errors []error) error {
 //
 // 	fmt.Sprintf("%+v", multierr.Combine(err1, err2))
 func Combine(errors ...error) error {
-	return fromSlice(errors)
+	switch len(errors) {
+	case 0:
+		return nil
+	case 1:
+		return errors[0]
+	case 2:
+		return Append(errors[0], errors[1])
+	default:
+		wasNil := true
+		for _, err := range errors {
+			if err != nil {
+				wasNil = false
+				break
+			}
+		}
+		if wasNil {
+			return nil
+		}
+
+		// If we don't copy the errors slice the escape analysis will mark errors
+		// and it will always be allocated on the heap.
+		errs := make([]error, len(errors))
+		copy(errs, errors)
+
+		return fromSlice(errs)
+	}
 }
 
 // Append appends the given errors together. Either value may be nil.

--- a/error.go
+++ b/error.go
@@ -442,21 +442,32 @@ func Combine(errors ...error) error {
 	case 2:
 		return Append(errors[0], errors[1])
 	default:
-		wasNil := true
-		for _, err := range errors {
+		idx := -1
+		onlyOne := false
+		// wasNil := true
+		for i, err := range errors {
 			if err != nil {
-				wasNil = false
-				break
+				if onlyOne {
+					onlyOne = false
+					break
+				}
+				onlyOne = true
+				idx = i
 			}
 		}
-		if wasNil {
+
+		if idx == -1 {
 			return nil
+		}
+
+		if onlyOne {
+			return errors[idx]
 		}
 
 		// If we don't copy the errors slice the escape analysis will mark errors
 		// and it will always be allocated on the heap.
-		errs := make([]error, len(errors))
-		copy(errs, errors)
+		errs := make([]error, len(errors)-idx)
+		copy(errs, errors[idx:])
 
 		return fromSlice(errs)
 	}

--- a/error.go
+++ b/error.go
@@ -444,7 +444,6 @@ func Combine(errors ...error) error {
 	default:
 		idx := -1
 		onlyOne := false
-		// wasNil := true
 		for i, err := range errors {
 			if err != nil {
 				if onlyOne {
@@ -464,8 +463,8 @@ func Combine(errors ...error) error {
 			return errors[idx]
 		}
 
-		// If we don't copy the errors slice the escape analysis will mark errors
-		// and it will always be allocated on the heap.
+		// If we don't copy the errors slice here the escape analysis will mark
+		// it, which will result in a heap allocation on every call.
 		errs := make([]error, len(errors)-idx)
 		copy(errs, errors[idx:])
 

--- a/error.go
+++ b/error.go
@@ -372,6 +372,14 @@ func inspect(errors []error) (res inspectResult) {
 
 // fromSlice converts the given list of errors into a single error.
 func fromSlice(errors []error) error {
+	// Don't pay to inspect small slices.
+	switch len(errors) {
+	case 0:
+		return nil
+	case 1:
+		return errors[0]
+	}
+
 	res := inspect(errors)
 	switch res.Count {
 	case 0:

--- a/error.go
+++ b/error.go
@@ -389,9 +389,10 @@ func fromSlice(errors []error) error {
 		return errors[res.FirstErrorIdx]
 	case len(errors):
 		if !res.ContainsMultiError {
-			// Error list is flat.
-			// Make a copy of it (otherwise "errors" escapes to the
-			// heap) unconditionally for all other cases.
+			// Error list is flat. Make a copy of it
+			// Otherwise "errors" escapes to the heap
+			// unconditionally for all other cases.
+			// This lets us optimize for the "no errors" case.
 			out := make([]error, len(errors))
 			copy(out, errors)
 			return &multiError{errors: out}

--- a/error_test.go
+++ b/error_test.go
@@ -274,17 +274,11 @@ func TestCombineDoesNotModifySlice(t *testing.T) {
 }
 
 func TestCombineGoodCaseNoAlloc(t *testing.T) {
-	var x, y, z error
+	errs := make([]error, 10)
 	allocs := testing.AllocsPerRun(100, func() {
-		Combine(x, y, z)
+		Combine(errs...)
 	})
 	assert.Equal(t, 0.0, allocs)
-}
-
-func TestOptimize(t *testing.T) {
-	errs := make([]error, 100)
-	errs[len(errs)-1] = fmt.Errorf("failed")
-	Combine(errs...)
 }
 
 func TestAppend(t *testing.T) {

--- a/error_test.go
+++ b/error_test.go
@@ -281,6 +281,12 @@ func TestCombineGoodCaseNoAlloc(t *testing.T) {
 	assert.Equal(t, 0.0, allocs)
 }
 
+func TestOptimize(t *testing.T) {
+	errs := make([]error, 100)
+	errs[len(errs)-1] = fmt.Errorf("failed")
+	Combine(errs...)
+}
+
 func TestAppend(t *testing.T) {
 	tests := []struct {
 		left  error

--- a/error_test.go
+++ b/error_test.go
@@ -98,6 +98,12 @@ func TestCombine(t *testing.T) {
 			wantSingleline: "foo; bar",
 		},
 		{
+			giveErrors:     []error{nil, nil, errors.New("great sadness"), nil},
+			wantError:      errors.New("great sadness"),
+			wantMultiline:  "great sadness",
+			wantSingleline: "great sadness",
+		},
+		{
 			giveErrors: []error{
 				errors.New("foo"),
 				newMultiErr(

--- a/error_test.go
+++ b/error_test.go
@@ -273,6 +273,14 @@ func TestCombineDoesNotModifySlice(t *testing.T) {
 	assert.Nil(t, errors[1], 3)
 }
 
+func TestCombineGoodCaseNoAlloc(t *testing.T) {
+	var x, y, z error
+	allocs := testing.AllocsPerRun(100, func() {
+		Combine(x, y, z)
+	})
+	assert.Equal(t, 0.0, allocs)
+}
+
 func TestAppend(t *testing.T) {
 	tests := []struct {
 		left  error


### PR DESCRIPTION
During the work on https://github.com/yarpc/yarpc-go/pull/2126 I found that `multierr.Combine` always allocates the error slice on the heap because of the escape analysis.

Assuming that most cases where `multierr.Combine` is called all arguments are `nil` it make sense to optimize it with that in mind: 

Benchmark results for this optimization:
```
name                              old time/op    new time/op    delta
Combine/inline_1                    29.3ns ±15%     2.0ns ± 7%   -93.28%  (p=0.000 n=10+9)
Combine/inline_2                    40.0ns ± 6%     3.4ns ±11%   -91.55%  (p=0.000 n=10+10)
Combine/inline_3_no_error           41.9ns ± 2%     4.8ns ±15%   -88.41%  (p=0.000 n=8+10)
Combine/inline_3_one_error          41.6ns ± 3%     5.3ns ± 5%   -87.18%  (p=0.000 n=9+10)
Combine/inline_3_multiple_errors    81.0ns ± 9%   115.8ns ±16%   +42.96%  (p=0.000 n=10+10)
Combine/slice_100_no_errors          432ns ±12%      99ns ± 8%   -77.20%  (p=0.000 n=10+10)
Combine/slice_100_one_error          555ns ±12%     182ns ± 6%   -67.15%  (p=0.000 n=10+9)
Combine/slice_100_multi_error        832ns ± 6%     919ns ± 7%   +10.38%  (p=0.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
Combine/inline_1                     16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Combine/inline_2                     32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_no_error            48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_one_error           48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_multiple_errors     80.0B ± 0%     80.0B ± 0%      ~     (all equal)
Combine/slice_100_no_errors         1.79kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
Combine/slice_100_one_error         1.82kB ± 0%    0.02kB ± 0%   -98.68%  (p=0.000 n=10+10)
Combine/slice_100_multi_error       1.90kB ± 0%    1.90kB ± 0%      ~     (all equal)

name                              old allocs/op  new allocs/op  delta
Combine/inline_1                      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Combine/inline_2                      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_no_error             1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_one_error            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Combine/inline_3_multiple_errors      2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Combine/slice_100_no_errors           1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Combine/slice_100_one_error           3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
Combine/slice_100_multi_error         7.00 ± 0%      7.00 ± 0%      ~     (all equal)
```