### PR TITLE
Prepare release v1.8.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.16.x", "1.17.x"]
         include:
-        - go: 1.16.x
+        - go: 1.17.x
           latest: true
 
     steps:
@@ -26,7 +26,7 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v2
-      
+
     - name: Load cached dependencies
       uses: actions/cache@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Releases
 ========
 
+v1.8.0 (2022-02-28)
+===================
+
+-   `Combine`: perform zero allocations when there are no errors.
+
+
 v1.7.0 (2021-05-06)
 ===================
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build tools
 // +build tools
 
 package multierr


### PR DESCRIPTION
Release v1.8.0 with an optimized `Combine`.
Test with Go 1.17 for it.
