### PR TITLE
Add a shorthand for AppendInvoke

### DIFF
--- a/error.go
+++ b/error.go
@@ -660,3 +660,10 @@ func Close(closer io.Closer) Invoker {
 func AppendInvoke(into *error, invoker Invoker) {
 	AppendInto(into, invoker.Invoke())
 }
+
+// AppendFunc is a shorthand for AppendInvoke.
+// It allows using function or method value directly
+// without having to wrap it into an Invoker interface.
+func AppendFunc(into *error, fn func() error) {
+	AppendInvoke(into, Invoke(fn))
+}


### PR DESCRIPTION
I really like the idea of catching returned errors from deferred functions. Though having to use `multierr` package name twice in the same line makes it a bit verbose in many occasions.

This PR introduces a shorthand for AppendInvoke which allows passing function or method value directly without wrapping it into an Invoker.

So this:

```go
defer multierr.AppendInvoke(&err, multierr.Invoke(my.StopFunc))
```

could become this:

```go
defer multierr.AppendFunc(&err, my.StopFunc)
```