### PR TITLE
Prepare release v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 Releases
 ========
 
-v1.10.0 (unreleased)
+v1.10.0 (2023-03-08)
 ====================
 
 -   Comply with Go 1.20's multiple-error interface.
+-   Drop Go 1.18 support.
+    Per the support policy, only Go 1.19 and 1.20 are supported now.
+-   Drop all non-test external dependencies.
 
 v1.9.0 (2022-12-12)
 ===================


### PR DESCRIPTION
Prepares a new release with support for Go 1.20's
`Unwrap() []error` interface.
