### PR TITLE
Enable Errors support for any multi-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Releases
 ========
 
+Unreleased
+====================
+-   `Errors` now supports any error that implements multiple-error
+    interface.
+
 v1.10.0 (2023-03-08)
 ====================
 

--- a/error.go
+++ b/error.go
@@ -194,23 +194,7 @@ type errorGroup interface {
 //
 // Callers of this function are free to modify the returned slice.
 func Errors(err error) []error {
-	if err == nil {
-		return nil
-	}
-
-	// Note that we're casting to multiError, not errorGroup. Our contract is
-	// that returned errors MAY implement errorGroup. Errors, however, only
-	// has special behavior for multierr-specific error objects.
-	//
-	// This behavior can be expanded in the future but I think it's prudent to
-	// start with as little as possible in terms of contract and possibility
-	// of misuse.
-	eg, ok := err.(*multiError)
-	if !ok {
-		return []error{err}
-	}
-
-	return append(([]error)(nil), eg.Errors()...)
+	return extractErrors(err)
 }
 
 // multiError is an error that holds one or more errors.
@@ -224,8 +208,6 @@ type multiError struct {
 	copyNeeded atomic.Bool
 	errors     []error
 }
-
-var _ errorGroup = (*multiError)(nil)
 
 // Errors returns the list of underlying errors.
 //

--- a/error_post_go120_test.go
+++ b/error_post_go120_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2023 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,26 +23,20 @@
 
 package multierr
 
-// Unwrap returns a list of errors wrapped by this multierr.
-func (merr *multiError) Unwrap() []error {
-	return merr.Errors()
-}
+import (
+	"errors"
+	"testing"
 
-type multipleErrors interface {
-	Unwrap() []error
-}
+	"github.com/stretchr/testify/assert"
+)
 
-func extractErrors(err error) []error {
-	if err == nil {
-		return nil
-	}
+func TestErrorsOnErrorsJoin(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	err := errors.Join(err1, err2)
 
-	// check if the given err is an Unwrapable error that
-	// implements multipleErrors interface.
-	eg, ok := err.(multipleErrors)
-	if !ok {
-		return []error{err}
-	}
-
-	return append(([]error)(nil), eg.Unwrap()...)
+	errs := Errors(err)
+	assert.Equal(t, 2, len(errs))
+	assert.Equal(t, err1, errs[0])
+	assert.Equal(t, err2, errs[1])
 }

--- a/error_pre_go120.go
+++ b/error_pre_go120.go
@@ -57,3 +57,23 @@ func (merr *multiError) Is(target error) bool {
 	}
 	return false
 }
+
+func extractErrors(err error) []error {
+	if err == nil {
+		return nil
+	}
+
+	// Note that we're casting to multiError, not errorGroup. Our contract is
+	// that returned errors MAY implement errorGroup. Errors, however, only
+	// has special behavior for multierr-specific error objects.
+	//
+	// This behavior can be expanded in the future but I think it's prudent to
+	// start with as little as possible in terms of contract and possibility
+	// of misuse.
+	eg, ok := err.(*multiError)
+	if !ok {
+		return []error{err}
+	}
+
+	return append(([]error)(nil), eg.Errors()...)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -386,7 +386,8 @@ func TestErrors(t *testing.T) {
 			dontCast: true,
 		},
 		{
-			// We don't yet support non-multierr errors.
+			// We don't yet support non-multierr errors that do
+			// not implement Unwrap() []error.
 			give:     notMultiErr{},
 			want:     []error{notMultiErr{}},
 			dontCast: true,


### PR DESCRIPTION
Starting Go 1.20, any multi-error should conform to the standard unwrap method: Unwrap() []error.

This changes multierr.Errors() method to support any error that complies to that interface.

Fix #70 / GO-1883