### PR TITLE
ci: Minimize permissions to workflows

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,6 +1,9 @@
 name: FOSSA Analysis
 on: push
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: ['*']
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Reduces the permissions available to GitHub Workflows
to read-only since they don't do much otherwise.

Resolves #76
