### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 Releases
 ========
 
-Unreleased
+v1.11.0 (2023-03-28)
 ====================
 -   `Errors` now supports any error that implements multiple-error
     interface.
+-   Add `Every` function to allow checking if all errors in the chain
+    satisfies `errors.Is` against the target error.
 
 v1.10.0 (2023-03-08)
 ====================


### PR DESCRIPTION
This prepares release for v1.11.0 which contains:
*  support for `Errors` on any error that implements the multiple-error interface specified by standard library starting from Go 1.20.
* `Every`, which checks whether all errors in the error chain satisfies the `errors.Is` comparison against the target error.