### PR TITLE
CI: Test against go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.20.x", "1.21.x"]
+        go: ["1.21.x", "1.22.x"]
         include:
-        - go: 1.21.x
+        - go: 1.22.x
           latest: true
 
     steps:


### PR DESCRIPTION
Upgrades CI workflows to use Go versions 1.21 and 1.22.

Leave `go.mod` the same to avoid forcing upgrade beyond 1.20 for users.